### PR TITLE
Fix deprecated divide warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ wpi.java.configureTestTasks(test)
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
+    options.compilerArgs << '-Werror'
     options.encoding = 'UTF-8'
     options.failOnError = true         // Ensure compilation errors cause build failure
 }


### PR DESCRIPTION
Treat warnings as errors. Maybe it will be too annoying and then it can be reverted.