### PR TITLE
Collect git properties and log them at robot start-up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,25 @@ plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2025.3.1"
     id "com.diffplug.spotless" version "6.20.0"
+    id "com.gorylenko.gradle-git-properties" version '2.5.0'
 }
+
+gitProperties {
+    keys = [
+        'git.branch',
+        'git.build.host',
+        'git.commit.id.abbrev',
+        'git.commit.message.short',
+        'git.commit.time',
+        'git.commit.user.email',
+        'git.commit.user.name',
+        'git.dirty',
+    ]
+    dateFormat = "yyyy-MM-dd HH:mm:ss"
+    dateFormatTimeZone = "America/Los_Angeles"
+}
+
+generateGitProperties.outputs.upToDateWhen { false } // make sure the generateGitProperties task always executes (even when git.properties is not changed)
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
Uses [gradle-git-properties](
https://github.com/n0mer/gradle-git-properties/blob/master/README.md) plugin

Example from running `./gradlew simulateJava`:
```
********** Robot program starting **********
NT: Listening on NT3 port 1735, NT4 port 5810
DataLog: Logging to '/work/logs/FRC_TBD_fc1f1ee06a3833d1.wpilog' (514.0 GiB free space)
git.commit.message.short: Fix all formatting issues with ./gradlew spotlessApply
git.commit.user.email: <elided>
git.commit.user.name: <elided>
git.commit.id.abbrev: fba9a73
git.branch: gnezdo/log-build-commit
git.build.host: e269da2395a7
git.commit.time: 2025-03-07 20:52:42
git.dirty: true
```
