### PR TITLE
Make sure jar task depends on generateGitProperties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,9 @@ jar {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
+// Make sure jar task depends on generateGitProperties
+jar.dependsOn generateGitProperties
+
 // Configure jar and deploy tasks
 deployArtifact.jarTask = jar
 wpi.java.configureExecutableTasks(jar)


### PR DESCRIPTION
This should ensure the git info shows up in logs.